### PR TITLE
Film Location & View Page Fixes

### DIFF
--- a/fort_macarthur/lib/filmLocation.dart
+++ b/fort_macarthur/lib/filmLocation.dart
@@ -99,7 +99,7 @@ class _FilmLocationState extends State<FilmLocation> {
   createCard(image, description) {
     return Container(
         width: Device.width / 5.3,
-        height: Device.height / 9.0,
+        height: Device.height / 8.5,
         child: Card(
           child: InkWell(
             splashColor: Colors.blue.withAlpha(30),

--- a/fort_macarthur/lib/viewpage.dart
+++ b/fort_macarthur/lib/viewpage.dart
@@ -17,15 +17,15 @@ class _ViewPageState extends State<Viewpage> {
     "Home",
     "Test",
     "Virtual Tours",
+    "Film Location",
     "Projects",
-    "Film Location"
   ];
   List<Widget> pagelist = [
     HomePage(),
     TestPage(),
     VirtualTours(),
+    FilmLocation(),
     ProjectsPage(),
-    FilmLocation()
   ]; // add your pages here
 
   @override


### PR DESCRIPTION
### What Changed
Fixed View Page ordering so now Film Location and Projects have their proper Appbar titles.
Fixed Overflow on Cards on Film Location Page while on 8'' Tablet.

### Please Look At
Appbar Titles for Projects and FilmLocation pages and make sure they are correct.
Also please give the changes in code a quick look over to make sure they are fine.