### PR TITLE
Sorted pixel overflow for cards in post history and film location

### DIFF
--- a/fort_macarthur/lib/filmLocation.dart
+++ b/fort_macarthur/lib/filmLocation.dart
@@ -17,7 +17,6 @@ class _FilmLocationState extends State<FilmLocation> {
   @override
   Widget build(BuildContext context) {
     Device.init();
-
     return Scaffold(
         backgroundColor: Device.backroundCOLOR,
         body: Container(
@@ -98,25 +97,26 @@ class _FilmLocationState extends State<FilmLocation> {
 
   createCard(image, description) {
     return Container(
-        width: Device.width / 5.3,
-        height: Device.height / 8.5,
-        child: Card(
-          child: InkWell(
-            splashColor: Colors.blue.withAlpha(30),
-            onTap: () {
-              createOverlay(image, description);
-            },
-            child: Column(
-              children: [
-                Image.asset(image, fit: BoxFit.fitWidth),
-                Text(
-                  description,
-                  textAlign: TextAlign.center,
-                ),
-              ],
-            ),
+      width: Device.safeBlockHorizontal * 50,
+      height: Device.height / 8.5,
+      child: Card(
+        child: InkWell(
+          splashColor: Colors.blue.withAlpha(30),
+          onTap: () {
+            createOverlay(image, description);
+          },
+          child: Column(
+            children: [
+              Image.asset(image, fit: BoxFit.fitWidth),
+              Text(
+                description,
+                textAlign: TextAlign.center,
+              ),
+            ],
           ),
-        ));
+        ),
+      ),
+    );
   }
 
   createOverlay(image, description) {

--- a/fort_macarthur/lib/posthistoryview.dart
+++ b/fort_macarthur/lib/posthistoryview.dart
@@ -127,7 +127,6 @@ class _PostHistoryState extends State<PostHistoryPage> {
   @override
   Widget build(BuildContext context) {
     Device.init();
-
     return Scaffold(
         backgroundColor: Device.backroundCOLOR,
         body: Container(
@@ -148,7 +147,7 @@ class _PostHistoryState extends State<PostHistoryPage> {
 
   createCard(title, mainImage, description, photos) {
     return Container(
-        width: Device.width / 5.3,
+        width: Device.safeBlockHorizontal * 50,
         height: Device.height / 8.5,
         child: Card(
           child: InkWell(


### PR DESCRIPTION
Utilised the device.dart file to sort out static sizing issues in the cards for both the film location and post histories screens.

film location now fits width wise across screen.
![filmloc](https://user-images.githubusercontent.com/45257691/120672607-5d9c7e00-c48a-11eb-94a6-bdb99e56b72c.PNG)

... as does post history
![post_his](https://user-images.githubusercontent.com/45257691/120672696-7016b780-c48a-11eb-84a2-599f3a12a574.PNG)


Run on as many different emulators as you can in order to test that is now uniform across as many screens as possible
