### PR TITLE
Virtual tours cleanup

### DIFF
--- a/fort_macarthur/lib/battery_details.dart
+++ b/fort_macarthur/lib/battery_details.dart
@@ -11,6 +11,7 @@ class BatteryDetails extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        backgroundColor: Colors.lightGreen[900],
         title: Text("Details"),
       ),
       backgroundColor: Device.backroundCOLOR,

--- a/fort_macarthur/lib/battery_history.dart
+++ b/fort_macarthur/lib/battery_history.dart
@@ -10,15 +10,16 @@ class BatteryHistory extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        backgroundColor: Colors.lightGreen[900],
         title: Text("History"),
       ),
       backgroundColor: Device.backroundCOLOR,
       body: Center(
-        child: Card(
-          shape:
-              RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
-          margin: EdgeInsets.symmetric(horizontal: 10, vertical: 20),
-          child: SingleChildScrollView(
+        child: SingleChildScrollView(
+          child: Card(
+            shape:
+                RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+            margin: EdgeInsets.symmetric(horizontal: 10, vertical: 20),
             child: Padding(
               padding: const EdgeInsets.symmetric(vertical: 15, horizontal: 10),
               child: Text(

--- a/fort_macarthur/lib/image_grid.dart
+++ b/fort_macarthur/lib/image_grid.dart
@@ -12,6 +12,7 @@ class ImageView extends StatelessWidget {
     return Scaffold(
       backgroundColor: Device.backroundCOLOR,
       appBar: AppBar(
+        backgroundColor: Colors.lightGreen[900],
         title: image.title != null ? Text(image.title!) : Text("Image"),
       ),
       body: InteractiveViewer(
@@ -45,6 +46,7 @@ class ImageGridView extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        backgroundColor: Colors.lightGreen[900],
         title: Text("Slideshow"),
       ),
       backgroundColor: Device.backroundCOLOR,

--- a/fort_macarthur/lib/panoramaView.dart
+++ b/fort_macarthur/lib/panoramaView.dart
@@ -12,6 +12,7 @@ class PanoView extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        backgroundColor: Colors.lightGreen[900],
         title: Text("Battery " + data.title),
       ),
       body: Stack(
@@ -25,6 +26,7 @@ class PanoView extends StatelessWidget {
           Container(
             margin: EdgeInsets.symmetric(vertical: 5, horizontal: 5),
             child: ElevatedButton.icon(
+              style: ElevatedButton.styleFrom(primary: Colors.lightGreen[900]),
               onPressed: () {
                 Navigator.push(
                     context,

--- a/fort_macarthur/lib/post_hist_panorama.dart
+++ b/fort_macarthur/lib/post_hist_panorama.dart
@@ -16,6 +16,7 @@ class PostHistoryView extends StatelessWidget {
     return Scaffold(
       backgroundColor: Device.backroundCOLOR,
       appBar: AppBar(
+        backgroundColor: Colors.lightGreen[900],
         title: Text(data.title + " Battery"),
       ),
       body: Column(

--- a/fort_macarthur/lib/virtual_tours.dart
+++ b/fort_macarthur/lib/virtual_tours.dart
@@ -11,7 +11,7 @@ class VirtualTours extends StatefulWidget {
 class _VirtualToursState extends State<VirtualTours> {
   final List<PanoData> batteryData = [
     PanoData(
-        title: "Osgood",
+        title: "Osgood-Farley",
         panoPath: "assets/images/osgood_pano.jpg",
         history: "Battery Osgood-Farley was constructed during the years 1916-1919 " +
             "under the fortification program outlined by the Taft Board Report of 1906. " +
@@ -100,7 +100,6 @@ class _VirtualToursState extends State<VirtualTours> {
           ImageGridData(
               imagePath: "assets/images/osgoodSlideshow/TIoperator.jpg")
         ]),
-    PanoData(title: "Farley", panoPath: "assets/images/farley_pano.jpg")
   ];
 
   @override
@@ -115,6 +114,8 @@ class _VirtualToursState extends State<VirtualTours> {
             mainAxisAlignment: MainAxisAlignment.spaceEvenly,
             children: batteryData
                 .map((data) => ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                        primary: Colors.lightGreen[900]),
                     onPressed: () {
                       Navigator.push(
                           context,


### PR DESCRIPTION
## Changes Made
- Changed color scheme for nav bar and buttons in the virtual tours section of the app.
- Merged "battery osgood" & "battery farley" buttons into one button labeled "battery osgood-farley".
- Altered scrolling logic in battery history page.

## Review
- All of the section within the virtual tours. Make sure everything still works as intended.
- Feedback on new color scheme.

![image](https://user-images.githubusercontent.com/45101664/121512271-71dc0000-c9e1-11eb-9577-f8eb5902d410.png)

## Note
I left the main nav bar alone since that's not a virtual tours specific nav bar.